### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: mypy src
 
       - name: Lint
-        run: ruff --format github src
+        run: ruff check src
 
       - name: Format Code
         run: black --check --diff --color src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.10.0
     hooks:
       - id: mypy
         language_version: python3.11
@@ -10,13 +10,13 @@ repos:
           - types-beautifulsoup4
           - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.288
+    rev: v0.4.9
     hooks:
       - id: ruff
         language_version: python3.11
         files: src
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 ]
 dependencies = [
     "browser-cookie3 == 0.19.1",
-    "bs4 == 0.0.1",
-    "requests == 2.32.2",
-    "rich == 13.7.0"
+    "bs4 == 0.0.2",
+    "requests == 2.32.3",
+    "rich == 13.7.1"
 ]
 
 [project.urls]
@@ -48,17 +48,17 @@ bcamp-dl = "bcamp_dl.cli:main"
 
 [project.optional-dependencies]
 tests = [
-    "black == 23.9.1",
-    "mypy == 1.7.1",
-    "ruff == 0.0.288",
+    "black == 24.4.2",
+    "mypy == 1.10.0",
+    "ruff == 0.4.9",
     "types-beautifulsoup4",
     "types-requests",
 ]
 build = [
-    "setuptools == 69.0.2",
-    "setuptools-scm == 7.1.0",
-    "build == 1.0.3",
-    "twine == 4.0.2"
+    "setuptools == 70.1.0",
+    "setuptools-scm == 8.1.0",
+    "build == 1.2.1",
+    "twine == 5.1.0"
 ]
 
 [build-system]
@@ -98,8 +98,10 @@ ignore_missing_imports = true
 
 [tool.ruff]
 cache-dir = ".cache/ruff"
-show-source = true
+output-format = "full"
 src = ["src"]
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
     "ANN101",  # Missing type annotation for self in method
@@ -122,8 +124,8 @@ ignore = [
     "TRY",     # TODO: Fix and enable
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/src/bcamp_dl/__init__.py
+++ b/src/bcamp_dl/__init__.py
@@ -1,4 +1,5 @@
 """Download your collection from Bandcamp."""
+
 from typing import Any
 
 __all__ = []

--- a/src/bcamp_dl/bcamp_dl.py
+++ b/src/bcamp_dl/bcamp_dl.py
@@ -1,4 +1,5 @@
 """Download your collection from Bandcamp."""
+
 import json
 import os
 import re


### PR DESCRIPTION
Updated the following dependencies:
- bs4 from 0.0.1 to 0.0.2
- requests from 2.32.2 to 2.32.3
- rich from 13.7.0 to 13.7.1

Updated build and test dependencies:
- black from 23.9.1 to 24.4.2
- mypy from 1.7.1 to 1.10.0
- ruff from 0.0.288 to 0.4.9
- setuptools from 69.0.2 to 70.1.0
- setuptools-scm from 7.1.0 to 8.1.0
- build from 1.0.3 to 1.2.1
- twine from 4.0.2 to 5.1.0